### PR TITLE
fix: pass http_status_code as long instead of int to work with the latest libcurl

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -346,7 +346,7 @@ worker_main(Datum main_arg)
 						} else {
 							CurlData *cdata = NULL;
 							char *contentType = NULL;
-							int http_status_code;
+							long http_status_code;
 
 							curl_easy_getinfo(eh, CURLINFO_RESPONSE_CODE, &http_status_code);
 							curl_easy_getinfo(eh, CURLINFO_CONTENT_TYPE, &contentType);


### PR DESCRIPTION
fix: pass http_status_code as long instead of int to work with the latest libcurl

Issue: https://github.com/supabase/pg_net/issues/127